### PR TITLE
Add scope-specific cache management to memoize

### DIFF
--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -1,6 +1,6 @@
 module Memoize
 using MacroTools: isexpr, combinedef, namify, splitarg, splitdef
-export @memoize, memories
+export @memoize, forget!
 
 # which(signature::Tuple) is only on 1.6, but previous julia versions
 # use the following code under the hood anyway.
@@ -65,11 +65,11 @@ macro memoize(args...)
         end
     end
 
-    @gensym cache
+    cache = gensym(:__cache__)
     mod = __module__
 
     body = quote
-        get!($cache, ($(tup...),)) do
+        get!($cache[2], ($(tup...),)) do
             $u($(identargs...); $(identkws...))
         end
     end
@@ -83,13 +83,14 @@ macro memoize(args...)
     end
 
     sig = :(Tuple{typeof($(def_dict[:name])), $((splitarg(arg)[2] for arg in def_dict[:args])...)} where {$(def_dict[:whereparams]...)})
+    tail = :(Tuple{$((splitarg(arg)[2] for arg in def_dict[:args])...)} where {$(def_dict[:whereparams]...)})
 
     scope = gensym()
     meth = gensym("meth")
 
     esc(quote
         # The `local` qualifier will make this performant even in the global scope.
-        local $cache = $cache_dict
+        local $cache = ($tail, $cache_dict)
 
         $scope = nothing
 
@@ -102,7 +103,7 @@ macro memoize(args...)
             # Notice that methods are hashed by their stored signature
             local $meth = $_which($sig)
             if $meth !== nothing && $meth.sig == $sig && isdefined($meth.module, :__memories__)
-                empty!(pop!($meth.module.__memories__, $meth.sig, []))
+                empty!(pop!($meth.module.__memories__, $meth.sig, (nothing, []))[2])
             end
         end
 
@@ -124,36 +125,34 @@ macro memoize(args...)
 end
 
 """
-    memories(f, [types], [module])
+    forget!(f, types)
     
-    Return an array containing all the memoized method caches for the function f
-    defined at global scope. May also contain caches of overwritten methods.
-    
-    This function takes the same arguments as the method methods.
+    If the method `which(f, types)`, is memoized, `empty!` its cache in the
+    scope of `f`.
 """
-memories(f, args...) = _memories(methods(f, args...))
-
-function _memories(ms::Base.MethodList)
-    caches = []
-    for m in ms
-        cache = memories(m)
-        cache !== nothing && push!(caches, cache)
+function forget!(f, types)
+    for name in propertynames(f) #if f is a closure, we walk its fields
+        if first(string(name), length("##__cache__")) == "##__cache__"
+            cache = getproperty(f, name)
+            if cache isa Core.Box
+                cache = cache.contents
+            end
+            (cache[1] == types) && empty!(cache[2])
+        end
     end
-    return caches
+    forget!(which(f, types)) #otherwise, a method would suffice
 end
 
 """
-    memories(m::Method)
+    forget!(m::Method)
     
-    If m, defined at global scope, has not been overwritten, return it's
-    memoized cache. Otherwise, return nothing or the cache of an overwritten
-    method.
+    If m, defined at global scope, is a memoized function, `empty!` its
+    cache.
 """
-function memories(m::Method)
+function forget!(m::Method)
     if isdefined(m.module, :__memories__)
-        return get(m.module.__memories__, m.sig, nothing)
+        empty!(get(m.module.__memories__, m.sig, (nothing, []))[2])
     end
-    return nothing
 end
 
 end

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -95,9 +95,7 @@ macro memoize(args...)
         $scope = nothing
 
         if isdefined($__module__, $(QuoteNode(scope)))
-            if !@isdefined($(def_dict[:name]))
-                function $(def_dict[:name]) end
-            end
+            function $(def_dict[:name]) end
 
             # If overwriting a method, empty the old cache.
             # Notice that methods are hashed by their stored signature

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -103,7 +103,7 @@ macro memoize(args...)
         # Notice that methods are hashed by their stored signature
         local $meth = $_which($sig, $world)
         if $meth !== nothing && $meth.sig == $sig
-            if $meth.module == $__module__ && @isdefined(__memories__)
+            if $meth.module == $__module__
                 empty!(pop!(__memories__, $meth.sig, []))
             elseif isdefined($meth.module, :__memories__)
                 empty!(pop!($meth.module.__memories__, $meth.sig, []))

--- a/src/Memoize.jl
+++ b/src/Memoize.jl
@@ -122,8 +122,8 @@ end
 """
     memories(f, [types], [module])
     
-    Return an array containing all the memoized method caches for the function f.
-    May also contain caches of overwritten methods.
+    Return an array containing all the memoized method caches for the function f
+    defined at global scope. May also contain caches of overwritten methods.
     
     This function takes the same arguments as the method methods.
 """
@@ -141,8 +141,9 @@ end
 """
     memories(m::Method)
     
-    If m has not been overwritten, return it's memoized cache. Otherwise,
-    return nothing or the cache of an overwritten method.
+    If m, defined at global scope, has not been overwritten, return it's
+    memoized cache. Otherwise, return nothing or the cache of an overwritten
+    method.
 """
 function memories(m::Method)
     if isdefined(m.module, :__memories__)


### PR DESCRIPTION
Doesn't invalidate overwritten local method caches because I think it's impossible to call the overwritten method anyway (all the definitions happen simultaneously). Allows users to invalidate specific instances of closures by directly accessing the closure. Sometimes needs to unbox the cache variables to get their contents.